### PR TITLE
Organized Process class so much

### DIFF
--- a/GameOffsetDumper/ConfigReader.cpp
+++ b/GameOffsetDumper/ConfigReader.cpp
@@ -1,7 +1,9 @@
 #include "ConfigReader.h"
 #include "toml.hpp"
+#include <optional>
 
-std::vector<SignatureInfo> ConfigReader::Read(const std::string& filename) {
+std::vector<SignatureInfo> ConfigReader::ReadSigs(const std::string& filename)
+{
     auto config = toml::parse(filename);
     std::vector<SignatureInfo> result = {};
     for (auto& target : config.at("targets").as_array()) {
@@ -9,4 +11,15 @@ std::vector<SignatureInfo> ConfigReader::Read(const std::string& filename) {
         result.push_back(si);
     }
     return result;
+}
+
+std::optional<std::string> ConfigReader::ReadGameName(const std::string &filename)
+{
+    auto config = toml::parse(filename);
+    auto result = toml::find_or(config, "game", "");
+    if (!result.empty()) {
+        return result;
+    } else {
+        return std::optional<std::string> {};
+    }
 }

--- a/GameOffsetDumper/ConfigReader.h
+++ b/GameOffsetDumper/ConfigReader.h
@@ -1,8 +1,10 @@
-#include <string_view>
 #include "SignatureInfo.h"
 #include <vector>
+#include <string>
+#include <optional>
 
 class ConfigReader {
 public:
-    static std::vector<SignatureInfo> Read(const std::string& filename);
+    static std::vector<SignatureInfo> ReadSigs(const std::string& filename);
+    static std::optional<std::string> ReadGameName(const std::string& filename);
 };

--- a/GameOffsetDumper/Process.h
+++ b/GameOffsetDumper/Process.h
@@ -5,7 +5,13 @@
 #include <string>
 
 class Process {
+    DWORD processID;
+    BYTE* moduleBaseAddress;
+    DWORD moduleBaseSize;
+    Process(const std::string& processName, const std::string& moduleName);
+    void GetProcID(const std::string& processName);
+    void GetModuleInfo(const std::string& moduleName);
 public:
-    static std::optional<DWORD> GetProcID(const char* procName);
-    static std::optional<std::pair<BYTE*, DWORD>> GetModuleInfo(DWORD processID, const std::string& moduleName);
+    static Process GetProcess(const std::string& processName, const std::string& moduleName);
+
 };

--- a/GameOffsetDumper/SignatureInfo.cpp
+++ b/GameOffsetDumper/SignatureInfo.cpp
@@ -10,7 +10,8 @@ SignatureInfo::SignatureInfo(std::string& name, std::string& signatureString, st
     }
 }
 
-std::vector<int> SignatureInfo::SigParserXX() const {
+std::vector<int> SignatureInfo::SigParserXX() const
+{
     int i = 0;
     int sigSize = this->signatureString.size();
     std::vector<int> result{};
@@ -27,7 +28,8 @@ std::vector<int> SignatureInfo::SigParserXX() const {
     return result;
 }
 
-std::vector<int> SignatureInfo::SigParserQuestion() const {
+std::vector<int> SignatureInfo::SigParserQuestion() const
+{
     int i = 0;
     int sigSize = this->signatureString.size();
     std::vector<int> result{};

--- a/GameOffsetDumper/main.cpp
+++ b/GameOffsetDumper/main.cpp
@@ -1,23 +1,18 @@
 #include <iostream>
 #include "ConfigReader.h"
 #include "Process.h"
+#include <optional>
 
-#define PROCESS_NAME "csgo.exe"
-
-int main() {
-    std::vector<SignatureInfo> configs = ConfigReader::Read(std::string("test.toml"));
-    for (SignatureInfo& config : configs) {
-        std::optional<DWORD> processID = Process::GetProcID(PROCESS_NAME);
-        if (!processID) {
-            std::cerr << "No such process \"" << PROCESS_NAME << "\"" << std::endl;
-            return 0;
-        }
-        auto result = Process::GetModuleInfo(*processID, config.module);
-        if (result) {
-            std::cout << (uintptr_t)result->first << std::endl;
-            std::cout << result->second << std::endl;
-        } else {
-            std::cerr << "No such module \"" << config.module << "\" in this game." << std::endl;
-        }
+int main()
+{
+    std::optional<std::string> gameName = ConfigReader::ReadGameName("config.toml");
+    if (!gameName) {
+        std::cerr << "Specify the name of the target game" << std::endl;
+        return 1;
+    }
+    std::vector<SignatureInfo> configs = ConfigReader::ReadSigs("config.toml");
+    for (SignatureInfo& config : configs)
+    {
+        Process p = Process::GetProcess(*gameName, config.module);
     }
 }


### PR DESCRIPTION
Now users can specify which game do they wanna target at in the config.toml file by writing game = "something.exe"

Process class has some member variables such as processID, moduleBaseSize, moduleBaseAddress. 
Moreover, it got constructor.